### PR TITLE
Support major version 1.3

### DIFF
--- a/StorageVillage/Module/ModuleData/Languages/strings_EN.xml
+++ b/StorageVillage/Module/ModuleData/Languages/strings_EN.xml
@@ -58,6 +58,10 @@
     <string id="CONFIRM" text="Confirm"/>
     <string id="CANCEL" text="Cancel"/>
 
+    <string id="STORAGE_SETTING" text="Storage Settings"/>
+    <string id="STORAGE_SETTING_TYPE" text="Storage Setting Type"/>
+    <string id="STORAGE_SETTING_HINT" text="Switch between different storage settings."/>
+
     <string id="BANK_SETTINGS" text="Bank Settings"/>
     <string id="BANK_INTEREST_RATE_SETTING" text="Bank Weekly Interest Rate"/>
     <string id="BANK_INTEREST_RATE_SETTING_HINT" text="Set the weekly interest rate decimal form"/>

--- a/StorageVillage/Module/SubModule.xml
+++ b/StorageVillage/Module/SubModule.xml
@@ -22,18 +22,6 @@
         <Tag key="IsNoRenderModeElement" value="false" />
       </Tags>
     </SubModule>
-    <SubModule>
-      <Name value="MCMv5" />
-      <DLLName value="MCMv5.dll" />
-      <SubModuleClassType value="MCM.MCMSubModule" />
-      <Tags />
-    </SubModule>
-    <SubModule>
-      <Name value="MCMv5 Basic Implementation" />
-      <DLLName value="MCMv5.dll" />
-      <SubModuleClassType value="MCM.Internal.MCMImplementationSubModule" />
-      <Tags />
-    </SubModule>
   </SubModules>
   <Xmls> 
     <XmlNode>                

--- a/StorageVillage/StorageVillage.csproj
+++ b/StorageVillage/StorageVillage.csproj
@@ -44,6 +44,7 @@
     </Reference>
     <Reference Include="MCMv5">
       <HintPath>$(GamePath)\Modules\Bannerlord.MBOptionScreen\bin\Win64_Shipping_Client\MCMv5.dll</HintPath>
+      <Private>false</Private>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System" />

--- a/StorageVillage/src/behavior/BanditBehaviour.cs
+++ b/StorageVillage/src/behavior/BanditBehaviour.cs
@@ -8,6 +8,7 @@ using TaleWorlds.CampaignSystem.Party;
 using TaleWorlds.CampaignSystem.Settlements;
 using TaleWorlds.CampaignSystem.ViewModelCollection;
 using TaleWorlds.Core;
+using TaleWorlds.Core.ImageIdentifiers;
 using TaleWorlds.Localization;
 
 namespace StorageVillage.src.behavior {
@@ -139,14 +140,14 @@ namespace StorageVillage.src.behavior {
         private void MenuConsequenceForTargetSettlement(MenuCallbackArgs args) {
             List<InquiryElement> options = new List<InquiryElement>();
             string title = new TextObject("{=koX9okuG}None").ToString();
-            options.Add(new InquiryElement((object)null, title, new ImageIdentifier(ImageIdentifierType.Null)));
+            options.Add(new InquiryElement((object)null, title, new EmptyImageIdentifier()));
 
             List<Settlement> settlements = Settlement.FindAll(settlement =>
                 settlement.IsCastle || settlement.IsTown || settlement.IsVillage).ToList();
             settlements.Sort((Settlement x, Settlement y) => x.Name.ToString().CompareTo(y.Name.ToString()));
 
             foreach (Settlement settlement in settlements) {
-                options.Add(new InquiryElement(settlement, settlement.Name.ToString(), new ImageIdentifier(ImageIdentifierType.Null)));
+                options.Add(new InquiryElement(settlement, settlement.Name.ToString(), new EmptyImageIdentifier()));
             }
 
             MBInformationManager.ShowMultiSelectionInquiry(new MultiSelectionInquiryData(
@@ -166,7 +167,7 @@ namespace StorageVillage.src.behavior {
         private void MenuConsequenceForTargetParty(MenuCallbackArgs args) {
             List<InquiryElement> options = new List<InquiryElement>();
             string title = new TextObject("{=koX9okuG}None").ToString();
-            options.Add(new InquiryElement((object)null, title, new ImageIdentifier(ImageIdentifierType.Null)));
+            options.Add(new InquiryElement((object)null, title, new EmptyImageIdentifier()));
             List<MobileParty> parties = MobileParty.AllLordParties.ToList();
             parties.Sort((MobileParty x, MobileParty y) => x.Name.ToString().CompareTo(y.Name.ToString()));
             foreach (MobileParty party in parties) {
@@ -175,7 +176,7 @@ namespace StorageVillage.src.behavior {
                     if (characterObject != null) {
                         CharacterCode characterCode = CampaignUIHelper.GetCharacterCode(party.LeaderHero.CharacterObject, false);
                         if (characterCode != null) {
-                            options.Add(new InquiryElement(party, party.Name.ToString(), new ImageIdentifier(characterCode)));
+                            options.Add(new InquiryElement(party, party.Name.ToString(), new CharacterImageIdentifier(characterCode)));
                         }
                     }
                 }
@@ -287,11 +288,11 @@ namespace StorageVillage.src.behavior {
             }
 
             if (targetSettlement != null) {
-                party.Ai.SetMovePatrolAroundSettlement(targetSettlement);
+                party.SetMovePatrolAroundSettlement(targetSettlement, MobileParty.NavigationType.All, false);
             }
 
             if (targetParty != null) {
-                party.Ai.SetMoveGoAroundParty(targetParty);
+                party.SetMoveGoAroundParty(targetParty, MobileParty.NavigationType.All);
             }
         }
     }

--- a/StorageVillage/src/behavior/BankBehavior.cs
+++ b/StorageVillage/src/behavior/BankBehavior.cs
@@ -30,7 +30,7 @@ namespace StorageVillage.src.behavior {
         public override void RegisterEvents() {
             CampaignEvents.OnSessionLaunchedEvent.AddNonSerializedListener(this, new Action<CampaignGameStarter>(OnSessionLaunched));
 
-            CampaignEvents.DailyTickEvent.AddNonSerializedListener(
+            CampaignEvents.WeeklyTickEvent.AddNonSerializedListener(
                 this,
                 new Action(this.HandleBankWeeklyTickEvent)
             );

--- a/StorageVillage/src/behavior/TroopBehavior.cs
+++ b/StorageVillage/src/behavior/TroopBehavior.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Helpers;
 using StorageVillage.src.util;
 using TaleWorlds.CampaignSystem;
 using TaleWorlds.CampaignSystem.GameMenus;
@@ -97,16 +98,16 @@ namespace StorageVillage.src.behavior {
                 troopsParty = new MobileParty();
             }
 
-            troopsParty.SetCustomName(new TextObject("{=TROOP_STORAGE}Troops Storage"));
-            PartyScreenManager.OpenScreenAsManageTroopsAndPrisoners(troopsParty);
+            troopsParty.Party.SetCustomName(new TextObject("{=TROOP_STORAGE}Troops Storage"));
+            PartyScreenHelper.OpenScreenAsManageTroopsAndPrisoners(troopsParty);
         }
 
         private void MenuConsequenceForDonateTroops(MenuCallbackArgs args) {
-            PartyScreenManager.OpenScreenAsDonateGarrisonWithCurrentSettlement();
+            PartyScreenHelper.OpenScreenAsDonateGarrisonWithCurrentSettlement();
         }
 
         private void MenuConsequenceForDonatePrisoner(MenuCallbackArgs args) {
-            PartyScreenManager.OpenScreenAsDonatePrisoners();
+            PartyScreenHelper.OpenScreenAsDonatePrisoners();
         }
 
         private void MenuConsequenceForLeave(MenuCallbackArgs args) {

--- a/StorageVillage/src/patch/InventoryPatches.cs
+++ b/StorageVillage/src/patch/InventoryPatches.cs
@@ -8,7 +8,6 @@ using TaleWorlds.CampaignSystem.Actions;
 using TaleWorlds.CampaignSystem.Inventory;
 using TaleWorlds.CampaignSystem.Settlements;
 using TaleWorlds.Core;
-using TaleWorlds.Engine;
 using TaleWorlds.Library;
 using TaleWorlds.Localization;
 
@@ -125,13 +124,11 @@ namespace StorageVillage.src.patch {
                     }
                 }
 
-                if (settings.foodDonationRelationIncrease) {
-                    if (relationIncrease > 0) {
-                        ChangeRelationAction.ApplyRelationChangeBetweenHeroes(playerHero, owner, relationIncrease);
-                    }
+                if (settings.foodDonationRelationIncrease && relationIncrease > 0) {
+                    ChangeRelationAction.ApplyRelationChangeBetweenHeroes(playerHero, owner, relationIncrease);
                 }
             }
-            if (settings.foodDonationRelationIncrease) {
+            if (settings.foodDonationRelationIncrease && relationIncrease > 0) {
                 MBReadOnlyList<Hero> notables = currentSettlement.Notables;
                 for (int i = 0; i < notables.Count; i++) {
                     Hero notable = notables[i];

--- a/StorageVillage/src/util/Constants.cs
+++ b/StorageVillage/src/util/Constants.cs
@@ -16,5 +16,8 @@ namespace StorageVillage.src.util {
         public static float FOOD_DONATE_RELATION_FACTOR = 0.005f;
         public static float FOOD_DONATE_INFLUENCE_FACTOR = 0.05f;
 
+        public static String STORAGE_SETTING_TYPE_GLOBAL = "Global Level";
+        public static String STORAGE_SETTING_TYPE_TOWN = "Town Level";
+
     }
 }

--- a/StorageVillage/src/util/Settings.cs
+++ b/StorageVillage/src/util/Settings.cs
@@ -1,6 +1,7 @@
 ﻿using MCM.Abstractions.Attributes;
 using MCM.Abstractions.Attributes.v2;
 using MCM.Abstractions.Base.PerSave;
+using MCM.Common;
 
 namespace StorageVillage.src.setting {
     public class StorageVillageSettings : AttributePerSaveSettings<StorageVillageSettings> {
@@ -9,24 +10,32 @@ namespace StorageVillage.src.setting {
         public override string Id => "StorageVillage";
         public override string DisplayName => $"StorageVillage {typeof(StorageVillageSettings).Assembly.GetName().Version.ToString(3)}";
 
+        [SettingPropertyDropdown("{=STORAGE_SETTING_TYPE}Storage Setting Type", Order = 0, RequireRestart = false, HintText = "{=STORAGE_SETTING_HINT}Switch between different storage settings.")]
+        [SettingPropertyGroup("{=STORAGE_SETTING}Storage Settings", GroupOrder = 0)]
+        public Dropdown<string> townStorageSetting { get; set; } = new Dropdown<string>(new string[]
+        {
+            util.Constants.STORAGE_SETTING_TYPE_GLOBAL,
+            util.Constants.STORAGE_SETTING_TYPE_TOWN
+        }, selectedIndex: 0);
+
         [SettingPropertyFloatingInteger("{=BANK_INTEREST_RATE_SETTING}Bank Weekly Interest Rate", 0f, 10.0f, HintText = "{=BANK_INTEREST_RATE_SETTING_HINT}Set the weekly interest rate in percentage", Order = 0, RequireRestart = false)]
-        [SettingPropertyGroup("{=BANK_SETTINGS}Bank Settings", GroupOrder = 0)]
+        [SettingPropertyGroup("{=BANK_SETTINGS}Bank Settings", GroupOrder = 1)]
         public float interestRate { get; private set; } = 2.0f;
 
         [SettingPropertyBool("{=FOOD_DONATION_SECURITY_ENABLE}Food Donation Security Increase enabled", Order = 0, RequireRestart = false)]
-        [SettingPropertyGroup("{=FOOD_DONATION_SETTING}Food Donation Settings", GroupOrder = 0)]
+        [SettingPropertyGroup("{=FOOD_DONATION_SETTING}Food Donation Settings", GroupOrder = 1)]
         public bool foodDonationSecurityIncrease { get; private set; } = true;
 
         [SettingPropertyBool("{=FOOD_DONATION_FOOD_ENABLE}Food Donation Food Increase enabled", Order = 0, RequireRestart = false)]
-        [SettingPropertyGroup("{=FOOD_DONATION_SETTING}Food Donation Settings", GroupOrder = 0)]
+        [SettingPropertyGroup("{=FOOD_DONATION_SETTING}Food Donation Settings", GroupOrder = 1)]
         public bool foodDonationFoodIncrease { get; private set; } = true;
 
         [SettingPropertyBool("{=FOOD_DONATION_RELATION_ENABLE}Food Donation Relation Increase enabled", Order = 0, RequireRestart = false)]
-        [SettingPropertyGroup("{=FOOD_DONATION_SETTING}Food Donation Settings", GroupOrder = 0)]
+        [SettingPropertyGroup("{=FOOD_DONATION_SETTING}Food Donation Settings", GroupOrder = 1)]
         public bool foodDonationRelationIncrease { get; private set; } = true;
 
         [SettingPropertyBool("{=FOOD_DONATION_INFLUENCE_ENABLE}Food Donation Influence Increase enabled", Order = 0, RequireRestart = false)]
-        [SettingPropertyGroup("{=FOOD_DONATION_SETTING}Food Donation Settings", GroupOrder = 0)]
+        [SettingPropertyGroup("{=FOOD_DONATION_SETTING}Food Donation Settings", GroupOrder = 1)]
         public bool foodDonationInfluenceIncrease { get; private set; } = true;
     }
 }


### PR DESCRIPTION
- Support game the major game release 1.3.7
  - One impact with the 1.3.7 migration: The item storage from the old version is lost
- Fixed a issue where the bank interest happen daily instead of weekly
- Add additonal support so the item storage can be configured for town level instead of global level.
  -  This can be configured in the mcm setting

